### PR TITLE
Describe BungeeCord built in PROXY protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 BungeeProxy is a BungeeCord plugin that enables compatibility with HAProxy's PROXY v1 and v2 protocols.
 
+**NB: Modern BungeeCord versions have PROXY protocol support built in with the `proxy_protocol` option for `listener` directives in `config.yml`**
+
 
 ## What's HAProxy?
 


### PR DESCRIPTION
Adds a sentence to README.md describing that BungeeCord has support for the PROXY protocol built in, and how it can be activated.

I was recently researching BungeeCord behind haproxy, and found this plugin before I found out that BungeeCord had the functionality built in. I believe it will be helpful for others to mention this in the README.